### PR TITLE
Bug fix: reset power item

### DIFF
--- a/game.js
+++ b/game.js
@@ -52,6 +52,7 @@ function resetGame() {
   gameState = 'playing';
   spawnTimer = 0;
   bossAppearEffect = 0;
+  powerItem = null;
 }
 
 document.addEventListener('keydown', e => { keyState[e.key] = true; });


### PR DESCRIPTION
## Summary
- fix leftover power-up item when restarting the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f51eea19083238e6dd36c9d8d5098