### PR TITLE
Bug fix: reset power item

### DIFF
--- a/game.js
+++ b/game.js
@@ -52,9 +52,15 @@ function resetGame() {
   gameState = 'playing';
   spawnTimer = 0;
   bossAppearEffect = 0;
+  powerItem = null;
 }
 
-document.addEventListener('keydown', e => { keyState[e.key] = true; });
+document.addEventListener('keydown', e => {
+  if([' ', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+    e.preventDefault();
+  }
+  keyState[e.key] = true;
+});
 document.addEventListener('keyup', e => { keyState[e.key] = false; });
 
 startBtn.onclick = function() {
@@ -229,7 +235,14 @@ function update() {
       if(hit(boss,b)) {
         boss.hp--;
         bullets.splice(j,1);
-        if(boss.hp<=0) {boss=null; playing=false; gameState='clear'; showRetry(); score+=3000;}
+        if(boss.hp<=0) {
+          boss = null;
+          playing = false;
+          gameState = 'clear';
+          showRetry();
+          score += 3000;
+          break; // avoid checking boss after it disappears
+        }
       }
     }
     for(let b of bossBullets) if(hit(player,b)) {playing=false;gameState='gameover';showRetry();}


### PR DESCRIPTION
## Summary
- fix leftover power-up item when restarting the game
- prevent the page from scrolling when pressing the space key to shoot

## Testing
- `node -c game.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f51eea19083238e6dd36c9d8d5098